### PR TITLE
Show routes info and instructions with the preferred unit-system

### DIFF
--- a/src/instructions_control.js
+++ b/src/instructions_control.js
@@ -41,7 +41,17 @@ module.exports = function (container, directions) {
 
         steps.append('div')
             .attr('class', 'mapbox-directions-step-distance')
-            .text(function (step) { return step.distance ? format.imperial(step.distance) : ''; });
+
+            .text(function (step) {
+              var distanceWithUnits;
+              if(step.distance){
+                var units = directions.options.units;
+                distanceWithUnits = (units == 'metric') ? format.metric(step.distance) : format.imperial(step.distance);
+              } else {
+                distanceWithUnits = '';
+              }
+              return distanceWithUnits;
+            });
 
         steps.on('mouseover', function (step) {
             directions.highlightStep(step);

--- a/src/routes_control.js
+++ b/src/routes_control.js
@@ -10,17 +10,16 @@ module.exports = function (container, directions) {
         map = _;
         return control;
     };
-
     container = d3.select(L.DomUtil.get(container))
         .classed('mapbox-directions-routes', true);
+
+
 
     directions.on('error', function () {
         container.html('');
     });
-
-    directions.on('load', function (e) {
+        directions.on('load', function (e) {
         container.html('');
-
         var routes = container.append('ul')
             .selectAll('li')
             .data(e.routes)
@@ -37,7 +36,11 @@ module.exports = function (container, directions) {
 
         routes.append('div')
             .attr('class', 'mapbox-directions-route-details')
-            .text(function (route) { return format.imperial(route.distance) + ', ' + format.duration(route.duration); });
+            .text(function (route) {
+                var units = directions.options.units;
+                var distanceWithUnits = (units == 'metric') ? format.metric(route.distance) : format.imperial(route.distance);
+                return distanceWithUnits +', ' + format.duration(route.duration);
+            });
 
         routes.on('mouseover', function (route) {
             directions.highlightRoute(route);


### PR DESCRIPTION
Upon successfull response, the routes info and instruction can now show
the distances with either metric or imperial units.We can do so by
setting an option on L.mapbox.directions().

-We can choose metric system setting option unit on directions creation
-Usage example : 

``` javascript
    directions = L.mapbox.directions({units: 'metric'});

//if we do not set it or if we misspell it , imperial (miles) system will be used
```

-If we not specify units or if we misspell it, imperial system will be
used by default
